### PR TITLE
feat: add sdk adaptor for IST TVL calculation

### DIFF
--- a/projects/agoric/README.md
+++ b/projects/agoric/README.md
@@ -1,0 +1,34 @@
+# Agoric Inter Protocol Stable Token (IST) Adapter
+
+This adapter tracks the Total Value Locked (TVL) for the Inter Protocol Stable Token (IST) on the Agoric chain.
+
+## Overview
+- **Chain**: Agoric
+- **Token**: IST (Inter Protocol Stable Token)
+- **Website**: https://inter.trade
+- **CoinGecko ID**: inter-stable-token
+
+## Functionality
+This adapter calculates the TVL for IST by:
+
+1. Querying data from the Agoric Subquery API (https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2).
+2. Fetching information about:
+   - Vault manager metrics
+   - Oracle prices
+   - Board auxiliaries (for decimal places)
+3. Calculating the total collateral value across different asset types using BigInt for precise calculations.
+4. Adjusting the collateral values based on oracle prices and decimal places.
+5. Summing up the adjusted collateral values to get the total TVL.
+
+## Implementation Details
+- Uses BigInt for all calculations to ensure precision with large numbers.
+- Oracle prices are stored as ratios (numerator/denominator) to avoid floating-point precision issues.
+- Collateral values are adjusted based on their respective decimal places before calculation.
+- The final TVL is represented as a BigInt
+
+## Data Sources
+- Vault Manager Metrics: Provides information about total collateral for each brand.
+- Oracle Prices: Gives the current price data for different asset types.
+- Board Auxiliaries: Provides decimal place information for each asset.
+
+The adapter aggregates this data to calculate an accurate TVL across all collateral types in the Agoric ecosystem.

--- a/projects/agoric/index.js
+++ b/projects/agoric/index.js
@@ -1,0 +1,78 @@
+const sdk = require("@defillama/sdk");
+const { postURL } = require('../helper/utils')
+
+const coinGeckoId = 'inter-stable-token';
+
+const queryData = async (query) => {
+  const url = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
+  try {
+    const response = await postURL(url, { query });
+    return response.data.data;
+  } catch (error) {
+    console.error('Error fetching data from Subquery:', error);
+    throw error;
+  }
+}
+
+const tvl = async () => {
+  const query = `
+    query {
+      vaultManagerMetrics {
+        nodes {
+          liquidatingCollateralBrand
+          totalCollateral
+        }
+      }
+      oraclePrices {
+        nodes {
+          typeInAmount
+          typeOutAmount
+          typeInName
+        }
+      }
+      boardAuxes {
+        nodes {
+          allegedName
+          decimalPlaces
+        }
+      }
+    }
+  `;
+  const data = await queryData(query);
+  let totalTVL = BigInt(0);
+
+  const collaterals = data.vaultManagerMetrics.nodes.reduce((acc, curr) => {
+    acc[curr.liquidatingCollateralBrand] = BigInt(curr.totalCollateral);
+    return acc;
+  }, {});
+
+  const oraclePrices = data.oraclePrices.nodes.reduce((acc, curr) => {
+    const typeOutAmount = BigInt(curr.typeOutAmount ?? '1');
+    const typeInAmount = BigInt(curr.typeInAmount ?? '1');
+    acc[curr.typeInName] = { numerator: typeOutAmount, denominator: typeInAmount };
+    return acc;
+  }, {});
+
+  const decimals = data.boardAuxes.nodes.reduce((acc, curr) => {
+    acc[curr.allegedName] = curr.decimalPlaces;
+    return acc;
+  }, {});
+
+  Object.entries(collaterals).forEach(([brand, collateralValue]) => {
+    const oraclePrice = oraclePrices[brand];
+    const decimalValues = BigInt(10) ** BigInt(decimals[brand] ?? 6);
+    const priceNumerator = oraclePrice.numerator * collateralValue;
+    const priceDenominator = oraclePrice.denominator * decimalValues;
+    totalTVL += priceNumerator / priceDenominator;
+  });
+
+  const balances = {};
+  sdk.util.sumSingleBalance(balances, coinGeckoId, totalTVL);
+  return balances;
+}
+
+module.exports = {
+  agoric: {
+    tvl,
+  },
+}

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -157,6 +157,7 @@
   "iotaevm",
   "iotex",
   "islm",
+  "agoric",
   "jbc",
   "joltify",
   "juno",


### PR DESCRIPTION
WILL ADD DESCRIPTIONS WHEN PR IS READY FOR DEFILLAMA



**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
Inter Protocol

##### Twitter Link:
https://x.com/inter_protocol

##### List of audit links if any:


##### Website Link:
https://inter.trade

##### Logo (High resolution, will be shown with rounded borders):
![Inter-Protocol-logo-symbol-color](https://github.com/user-attachments/assets/0d290ac0-7aae-4003-b790-5f9c2794a80c)


##### Current TVL:
5.85 M

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Agoric

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
inter-stable-token


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
inter-stable-token

##### Short Description (to be shown on DefiLlama):
Inter Protocol is a decentralized stable token protocol on Agoric, issuing IST, an over-collateralized, multi-collateralized stable token designed for secure, cross-chain transactions in the Cosmos ecosystem.

##### Token address and ticker if any:
Ticker is $IST

##### Category (full list at https://defillama.com/categories) *Please choose only one: 
CDP


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Independent Chainlink DON

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The price feeds powering Inter Protocol are operated by an independently run and managed DON, including 5 node operators that are also validators on the Agoric network. These are P2P, Simply Staking, 01node, Stakin and DSRV.
Price updates are supplied via open source Chainlink software to a custom smart contract implementation of Chainlink’s aggregator contracts compatible with Agoric’s javascript platform.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://inter.trade/oracle-network/
https://agoric.com/blog/announcements/agoric-chainlink-integration/
https://github.com/SimplyStaking/agoric-cl-setup-docs
https://github.com/SimplyStaking/agoric-cl-middleware
https://community.agoric.com/t/inter-protocol-vaults-contract-implementations/261/3 


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
Queries vault manager metrics, board auxes and oracle prices from agoric's subquery API. 
Fetches total collateral from vault manager metrics, decimal places from board auxes and computes typeOut/In ratio from oracle prices. 
In short, sums the following for each collateral:
```
(typeOutAmount * collateralValue) / (typeInAmount * (10^decimalPlaces))
```

##### Github org/user (Optional, if your code is open source, we can track activity):
